### PR TITLE
Added exports for types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,5 @@
 declare module 'vanilla-picker' {
-  interface Color {
+  export interface Color {
     rgba: number[];
     hsla: number[];
     rgbString: string;
@@ -9,9 +9,9 @@ declare module 'vanilla-picker' {
     hex: string;
   }
 
-  type ColorCallback = (color: Color) => void;
+  export type ColorCallback = (color: Color) => void;
 
-  interface Options {
+  export interface Options {
     parent?: HTMLElement;
     popup?: 'top' | 'bottom' | 'left' | 'right' | false;
     template?: string;
@@ -26,8 +26,8 @@ declare module 'vanilla-picker' {
     onOpen?: ColorCallback;
     onClose?: ColorCallback;
   }
-  
-  type Configuration = Options | HTMLElement;
+
+  export type Configuration = Options | HTMLElement;
 
   class Picker {
     constructor(options: Configuration);


### PR DESCRIPTION
Close #49 

We recently used this library in a project. When we discovered that there was no type export here, we were very upset. So now it's fixed :) Enjoy!

<img width="836" alt="image" src="https://github.com/Sphinxxxx/vanilla-picker/assets/77390775/9d060a37-c9c6-49a0-a6c6-e1144a6709b0">

Without this PR, we were doing something like this:

![telegram-cloud-photo-size-2-5359373313253690851-y](https://github.com/Sphinxxxx/vanilla-picker/assets/77390775/b8eb0e42-3559-4075-9225-bc50474119be)

